### PR TITLE
use regex used in other orgnr libs rather than personnummer libs

### DIFF
--- a/organisationsnummer/organisationsnummer.py
+++ b/organisationsnummer/organisationsnummer.py
@@ -49,7 +49,7 @@ class Organisationsnummer:
         self._number = number
 
         try:
-            reg = r"^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-\+]{0,1})?(\d{3})(\d{0,1})$"
+            reg = r"^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([-+]?)?(\d{3})(\d)$"
             match = re.match(reg, str(object=number))
 
             if not match:


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

I took the regex from the personnummer lib, which makes the luhn check in this library fail with an IndexError. This takes the regex from the JS organisationsnummer implementation
